### PR TITLE
chore: add healthy check to proxy and network info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data
+.env

--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ Aim to provide a simple and easy way to run [atomicals-electrumx-proxy](https://
 ```ini
 server=1
 txindex=1
+# required otherwised electrumx server would complain error:
+#   ERROR:Daemon:daemon service refused: Not Found. Retrying occasionally...
+# from https://github.com/kyuupichan/electrumx/issues/1061
+rest=1
 
 # genearate with [rpcauth.py](https://github.com/bitcoin/bitcoin/blob/master/share/rpcauth/rpcauth.py)
-# equals to `rpcuser=nextdao` and `rpcpassword=nextdao`
-rpcauth=nextdao:cca838b4b19bdc6093f4e0312550361c$213834a29e8488804946c196781059a7ee0ac2b48dbf896b4c6852060d9d83dd
+# Usage: ./rpcauth.py <user> <password>
+# `rpcuser=alice`
+# `rpcpassword=alice`
+rpcauth=alice:15054eef64cb1aa8551622c1ab881e94$e1a085f3bc2fb12f4a864181ecbf53bcfd39a8921c67304d3439d4e3638c777b
 
 rpcallowip=127.0.0.1
 rpcallowip=172.0.0.0/8
@@ -42,6 +48,10 @@ docker-compose pull && docker-compose up -d
 - the electrumx indexes stored in `./electrumx-data` directory.
 - use `docker-compose logs -f` to check the logs.
 - use `docker-compose down` to stop the server.
+
+**NOTE**: Due to Docker Desktop is migrated to Compose V2, Please
+replace the `docker-compose` to `docker compose` if you're
+using Docker Desktop. More details please refer to [Migrate to Compose V2](https://docs.docker.com/compose/migrate/)
 
 ### 3. Used in [atomicals-js](https://github.com/atomicals/atomicals-js)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       atomicals:
         ipv4_address: 192.168.251.252
     volumes:
-      - /data/electrumx:/data
+      - ./data:/data
     environment:
       - DAEMON_URL=${DAEMON_URL:?}
       - COIN=BitCoin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,59 @@
-version: '3'
+version: "3"
 services:
   proxy:
+    container_name: atomicals-electrumx-proxy
     image: lucky2077/atomicals-electrumx-proxy:latest
     restart: always
+    healthcheck:
+      test: "nc -z 192.168.251.253 8080"
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 45s
+    expose:
+      - 8080
     ports:
       - 8080:8080
+    networks:
+      atomicals:
+        ipv4_address: 192.168.251.253
     environment:
       - ELECTRUMX_PORT=50001
       - ELECTRUMX_HOST=electrumx
     depends_on:
       - electrumx
   electrumx:
-    image: lucky2077/atomicals-electrumx:v1.3.7.2
+    container_name: atomicals-electrumx
+    image: lucky2077/atomicals-electrumx:latest
     restart: always
     healthcheck:
-      test: "nc -z localhost 50001"
+      test: "nc -z 192.168.251.252 50001"
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+    expose:
+      - 50001 # tcp connection port
+      - 50002 # ssl connection port
+      - 50004 # websocket connection port
+      - 8000 # rpc service port
+    ports:
+      - 50001:50001
+      - 50002:50002
+      - 50004:50004
+      - 8000:8000
+    networks:
+      atomicals:
+        ipv4_address: 192.168.251.252
     volumes:
-      - ./electrumx-data:/data
+      - /data/electrumx:/data
     environment:
-      - DAEMON_URL=nextdao:nextdao@${IP:?}:8332
+      - DAEMON_URL=${DAEMON_URL:?}
       - COIN=BitCoin
-      - PEER_DISCOVERY=off
-      - PEER_ANNOUNCE=""
-      - MAX_SEND=3000000
+networks:
+  atomicals:
+    name: atomicals
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.251.0/24


### PR DESCRIPTION
Add a healthy check for atomicals-electrumx-proxy, as well as specifing the precious network information to each container.

Also add missing configuration guide for bitcoin-core, which related to issue #14 